### PR TITLE
fix entryEndpointId & parentEndpointId bug

### DIFF
--- a/noop.go
+++ b/noop.go
@@ -29,6 +29,10 @@ type NoopSpan struct {
 func (*NoopSpan) SetOperationName(string) {
 }
 
+func (*NoopSpan) GetOperationName() string {
+	return ""
+}
+
 func (*NoopSpan) SetPeer(string) {
 }
 
@@ -48,4 +52,12 @@ func (*NoopSpan) Error(time.Time, ...string) {
 }
 
 func (*NoopSpan) End() {
+}
+
+func (*NoopSpan) IsEntry() bool {
+	return false
+}
+
+func (*NoopSpan) IsExit() bool {
+	return false
 }

--- a/propagation/propagation.go
+++ b/propagation/propagation.go
@@ -181,7 +181,7 @@ func globalIDConvertString(id []int64) string {
 }
 
 func encodeCompressedField(id int32, text string) string {
-	if id > 0 {
+	if id != 0 {
 		return base64.StdEncoding.EncodeToString([]byte(fmt.Sprint(id)))
 	}
 	return base64.StdEncoding.EncodeToString([]byte("#" + text))

--- a/reporter/grpc.go
+++ b/reporter/grpc.go
@@ -162,6 +162,11 @@ func (r *gRPCReporter) registerInstance(name string) error {
 			props = append(props, kv)
 		}
 	}
+	language := &common.KeyStringValuePair{
+		Key:   "language",
+		Value: "go",
+	}
+	props = append(props, language)
 	in := &register.ServiceInstances{
 		Instances: []*register.ServiceInstance{
 			{

--- a/segment.go
+++ b/segment.go
@@ -54,6 +54,7 @@ type SegmentContext struct {
 	collect         chan<- ReportedSpan
 	refNum          *int32
 	spanIDGenerator *int32
+	FirstSpan       Span `json:"-"`
 }
 
 func (ctx SegmentContext) GetReadableGlobalTraceID() string {
@@ -179,6 +180,9 @@ func (s *segmentSpanImpl) createSegmentContext(parent segmentSpan) {
 		s.ParentSegmentID = s.SegmentID
 		s.ParentSpanID = s.SpanID
 		s.SpanID = atomic.AddInt32(s.Context().spanIDGenerator, 1)
+	}
+	if s.SegmentContext.FirstSpan == nil {
+		s.SegmentContext.FirstSpan = s
 	}
 }
 

--- a/span.go
+++ b/span.go
@@ -42,6 +42,7 @@ const (
 // Span interface as common span specification
 type Span interface {
 	SetOperationName(string)
+	GetOperationName() string
 	SetPeer(string)
 	SetSpanLayer(common.SpanLayer)
 	SetComponent(int32)
@@ -49,6 +50,8 @@ type Span interface {
 	Log(time.Time, ...string)
 	Error(time.Time, ...string)
 	End()
+	IsEntry() bool
+	IsExit() bool
 }
 
 func newLocalSpan(t *Tracer) *defaultSpan {
@@ -78,6 +81,10 @@ type defaultSpan struct {
 
 func (ds *defaultSpan) SetOperationName(name string) {
 	ds.OperationName = name
+}
+
+func (ds *defaultSpan) GetOperationName() string {
+	return ds.OperationName
 }
 
 func (ds *defaultSpan) SetPeer(peer string) {
@@ -120,6 +127,14 @@ func (ds *defaultSpan) Error(time time.Time, ll ...string) {
 
 func (ds *defaultSpan) End() {
 	ds.EndTime = time.Now()
+}
+
+func (ds *defaultSpan) IsEntry() bool {
+	return ds.SpanType == SpanTypeEntry
+}
+
+func (ds *defaultSpan) IsExit() bool {
+	return ds.SpanType == SpanTypeExit
 }
 
 // SpanOption allows for functional options to adjust behaviour

--- a/trace.go
+++ b/trace.go
@@ -196,6 +196,7 @@ func (t *Tracer) CreateExitSpan(ctx context.Context, operationName string, peer 
 	spanContext.NetworkAddress = peer
 	spanContext.ParentServiceInstanceID = t.instanceID
 
+	// Since 6.6.0, if first span is not entry span, then this is an internal segment(no RPC), rather than an endpoint.
 	// EntryEndpoint
 	firstSpan := span.Context().FirstSpan
 	firstSpanOperationName := firstSpan.GetOperationName()


### PR DESCRIPTION
Since skywalking-6.6.0, if first span is not entry span, then this is an internal segment(no RPC),rather than an endpoint.

Result:
* java -> go
<img width="1260" alt="java-go" src="https://user-images.githubusercontent.com/26432832/75610396-c4c2d880-5b4b-11ea-9211-39884143cf09.png">

* go -> java
<img width="1260" alt="go-java" src="https://user-images.githubusercontent.com/26432832/75610400-cb515000-5b4b-11ea-86ee-4c77dd83aa9b.png">

* go -> go
<img width="1257" alt="go-go" src="https://user-images.githubusercontent.com/26432832/75610401-cf7d6d80-5b4b-11ea-82b9-3639257e26aa.png">
