### PR TITLE
add 'Authentication' for grpc request

### DIFF
--- a/reporter/grpc.go
+++ b/reporter/grpc.go
@@ -29,8 +29,8 @@ import (
 	agentv3 "github.com/SkyAPM/go2sky/reporter/grpc/language-agent"
 	managementv3 "github.com/SkyAPM/go2sky/reporter/grpc/management"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/metadata"
 )
 
 const (

--- a/reporter/grpc_test.go
+++ b/reporter/grpc_test.go
@@ -166,6 +166,15 @@ func TestGRPCReporterOption(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:   "with auth",
+			option: WithAuthentication("test"),
+			verifyFunc: func(t *testing.T, reporter *gRPCReporter) {
+				if reporter.md.Get(authKey)[0] != "test" {
+					t.Error("error are not set Authentication")
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Requirement or improvement
Please describe about your requirements or improvement suggestions.
In some service provider user case, they asked for authentication of agent about data uplink. Add an optional config item in agent side, named auth.token. This token will go with every request.

Related issues
apache/skywalking#934