### PR TITLE
Update e2e test codes for passing percentile verify

### DIFF
--- a/test/e2e/example-server/main.go
+++ b/test/e2e/example-server/main.go
@@ -48,7 +48,7 @@ func init() {
 }
 
 func ServerHTTP(writer http.ResponseWriter, request *http.Request) {
-	time.Sleep(time.Duration(300)*time.Millisecond)
+	time.Sleep(time.Duration(500)*time.Millisecond)
 
 	clientReq, err := http.NewRequest(http.MethodPost, upstreamURL, nil)
 	if err != nil {

--- a/test/e2e/example-server/main.go
+++ b/test/e2e/example-server/main.go
@@ -48,7 +48,7 @@ func init() {
 }
 
 func ServerHTTP(writer http.ResponseWriter, request *http.Request) {
-	time.Sleep(time.Duration(100)*time.Millisecond)
+	time.Sleep(time.Duration(300)*time.Millisecond)
 
 	clientReq, err := http.NewRequest(http.MethodPost, upstreamURL, nil)
 	if err != nil {

--- a/test/e2e/example-server/main.go
+++ b/test/e2e/example-server/main.go
@@ -48,7 +48,7 @@ func init() {
 }
 
 func ServerHTTP(writer http.ResponseWriter, request *http.Request) {
-	time.Sleep(time.Duration(500)*time.Millisecond)
+	time.Sleep(time.Duration(500) * time.Millisecond)
 
 	clientReq, err := http.NewRequest(http.MethodPost, upstreamURL, nil)
 	if err != nil {

--- a/test/e2e/example-server/main.go
+++ b/test/e2e/example-server/main.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/SkyAPM/go2sky"
 	httpPlugin "github.com/SkyAPM/go2sky/plugins/http"
@@ -47,6 +48,8 @@ func init() {
 }
 
 func ServerHTTP(writer http.ResponseWriter, request *http.Request) {
+	time.Sleep(time.Duration(100)*time.Millisecond)
+
 	clientReq, err := http.NewRequest(http.MethodPost, upstreamURL, nil)
 	if err != nil {
 		writer.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
Added a 500ms sleep at the serveHTTP func for passing  [percentile verify](https://github.com/apache/skywalking/issues/4594) in e2e test.
