### PR TITLE
fix(grpc-reporter): fix close stream to avoid goroutine leaks

### DIFF
--- a/reporter/grpc.go
+++ b/reporter/grpc.go
@@ -19,6 +19,7 @@ package reporter
 
 import (
 	"context"
+	"io"
 	"log"
 	"os"
 	"time"
@@ -252,8 +253,8 @@ func (r *gRPCReporter) initSendPipeline() {
 }
 
 func (r *gRPCReporter) closeStream(stream agentv3.TraceSegmentReportService_CollectClient) {
-	err := stream.CloseSend()
-	if err != nil {
+	_, err := stream.CloseAndRecv()
+	if err != nil && err != io.EOF {
 		r.logger.Printf("send closing error %v", err)
 	}
 }


### PR DESCRIPTION
Hello,there is an usage mistake on grpc stream control

here is the note from grpc doc 

note that when stream is abort,one of those action should be done but now none of them was execute

it lead a result that ,when stream connection recreate(such as using load balance),a goroutine created from `grpc.newClientStream` leaks

https://godoc.org/google.golang.org/grpc#ClientConn.NewStream

```
1. Call Close on the ClientConn.
2. Cancel the context provided.
3. Call RecvMsg until a non-nil error is returned. A protobuf-generated
   client-streaming RPC, for instance, might use the helper function
   CloseAndRecv (note that CloseSend does not Recv, therefore is not
   guaranteed to release all resources).
4. Receive a non-nil, non-io.EOF error from Header or SendMsg.
```