### PR TITLE
Fix panic when calling putCorrelation

### DIFF
--- a/correlation.go
+++ b/correlation.go
@@ -48,6 +48,9 @@ func PutCorrelation(ctx context.Context, key, value string) bool {
 		return false
 	}
 	correlationContext := span.context().CorrelationContext
+	if correlationContext == nil {
+		return false
+	}
 	// remove key
 	if value == "" {
 		delete(correlationContext, key)

--- a/correlation.go
+++ b/correlation.go
@@ -48,9 +48,6 @@ func PutCorrelation(ctx context.Context, key, value string) bool {
 		return false
 	}
 	correlationContext := span.context().CorrelationContext
-	if correlationContext == nil {
-		return false
-	}
 	// remove key
 	if value == "" {
 		delete(correlationContext, key)

--- a/correlation_test.go
+++ b/correlation_test.go
@@ -94,6 +94,31 @@ func TestGetCorrelation_WithTracingContest(t *testing.T) {
 			}(),
 		},
 		{
+			name: "existing context with empty correlation",
+			extractor: func(headerKey string) (string, error) {
+				if headerKey == propagation.HeaderCorrelation {
+					return "", nil
+				}
+				if headerKey == propagation.Header {
+					return "1-MWYyZDRiZjQ3YmY3MTFlYWI3OTRhY2RlNDgwMDExMjI=-MWU3YzIwNGE3YmY3MTFlYWI4NThhY2RlNDgwMDExMjI=" +
+						"-0-c2VydmljZQ==-aW5zdGFuY2U=-cHJvcGFnYXRpb24=-cHJvcGFnYXRpb246NTU2Ng==", nil
+				}
+				return "", nil
+			},
+			extracted: func() map[string]string {
+				m := make(map[string]string)
+				return m
+			}(),
+			customCase: func(ctx context.Context, t *testing.T) {
+				verifyPutResult(ctx, correlationTestKey, correlationTestValue, true, t)
+			},
+			want: func() map[string]string {
+				m := make(map[string]string)
+				m[correlationTestKey] = correlationTestValue
+				return m
+			}(),
+		},
+		{
 			name: "empty context with put bound judge",
 			extractor: func(headerKey string) (string, error) {
 				return "", nil

--- a/segment.go
+++ b/segment.go
@@ -191,6 +191,9 @@ func (s *segmentSpanImpl) createSegmentContext(parent segmentSpan) (err error) {
 	if s.SegmentContext.FirstSpan == nil {
 		s.SegmentContext.FirstSpan = s
 	}
+	if s.CorrelationContext == nil {
+		s.CorrelationContext = make(map[string]string)
+	}
 	return
 }
 


### PR DESCRIPTION
When current is has existing tracing context and empty correlation context, calling the `go2sky.putCorrelation` method will throw a panic.

So when creating the segment context, should check the correlation is empty, if so, need to add the default map. 
- [x] fix the panic bug.
- [x] add a unit test case.