### PR TITLE
fix(tracer): fixed create exit span with context error when current context not to be sampled

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -153,10 +153,10 @@ func (t *Tracer) CreateExitSpanWithContext(ctx context.Context, operationName st
 	if err != nil {
 		return
 	}
-	noopSpan, ok := interface{}(s).(NoopSpan)
+	noopSpan, ok := interface{}(s).(*NoopSpan)
 	if ok {
 		// Ignored, there is no need to inject SW8 in the request header
-		return &noopSpan, nCtx, nil
+		return noopSpan, nCtx, nil
 	}
 	s.SetPeer(peer)
 	spanContext := &propagation.SpanContext{}


### PR DESCRIPTION
In the tracer CreateExitSpanWithContext function, when the context is not a sample in this time, it
will be return a "span type is wrong" error.

Because trying to check the span is NoopSpan when after called CreateLocalSpan function, the convertion is expected a struct value.

But actual, the CreateLocalSpan function return a Span is a interface type, a interface type is a pointer in golang.

So we need to change the convertion to expect a pointer of NoopSpan type.

fix #113