### PR TITLE
feat: add validity check for span

### DIFF
--- a/noop.go
+++ b/noop.go
@@ -60,3 +60,7 @@ func (*NoopSpan) IsEntry() bool {
 func (*NoopSpan) IsExit() bool {
 	return false
 }
+
+func (*NoopSpan) IsValid() bool {
+	return false
+}

--- a/noop.go
+++ b/noop.go
@@ -62,5 +62,5 @@ func (*NoopSpan) IsExit() bool {
 }
 
 func (*NoopSpan) IsValid() bool {
-	return false
+	return true
 }

--- a/noop_test.go
+++ b/noop_test.go
@@ -90,10 +90,16 @@ func TestNoopSpanFromBegin(t *testing.T) {
 func TestNoopMethod(t *testing.T) {
 	n := NoopSpan{}
 	n.SetOperationName("aa")
+	if n.GetOperationName() != "" {
+		t.Error("operation name should be void string")
+	}
 	n.SetPeer("localhost:1111")
 	n.SetSpanLayer(agentv3.SpanLayer_Database)
 	n.SetComponent(2)
 	n.Tag("key", "value")
 	n.Log(time.Now(), "key", "value")
 	n.Error(time.Now(), "key", "value")
+	if n.IsValid() {
+		t.Error("noop span is valid")
+	}
 }

--- a/noop_test.go
+++ b/noop_test.go
@@ -99,7 +99,7 @@ func TestNoopMethod(t *testing.T) {
 	n.Tag("key", "value")
 	n.Log(time.Now(), "key", "value")
 	n.Error(time.Now(), "key", "value")
-	if n.IsValid() {
-		t.Error("noop span is valid")
+	if !n.IsValid() {
+		t.Error("noop span is not valid")
 	}
 }

--- a/segment.go
+++ b/segment.go
@@ -91,6 +91,9 @@ type segmentSpanImpl struct {
 
 // For Span
 func (s *segmentSpanImpl) End() {
+	if !s.IsValid() {
+		return
+	}
 	s.defaultSpan.End()
 	go func() {
 		s.Context().collect <- s
@@ -204,6 +207,9 @@ type rootSegmentSpan struct {
 }
 
 func (rs *rootSegmentSpan) End() {
+	if !rs.IsValid() {
+		return
+	}
 	rs.defaultSpan.End()
 	go func() {
 		rs.doneCh <- atomic.SwapInt32(rs.Context().refNum, -1)

--- a/segment_test.go
+++ b/segment_test.go
@@ -42,6 +42,15 @@ func TestSyncSegment(t *testing.T) {
 	if err := mr.Verify(2); err != nil {
 		t.Error(err)
 	}
+
+	if eSpan.IsValid() {
+		t.Error("exit span is still valid")
+	}
+	eSpan.End() // not be panic
+	if span.IsValid() {
+		t.Error("entry span is still valid")
+	}
+	span.End() // not be panic
 }
 
 func TestAsyncSingleSegment(t *testing.T) {

--- a/span.go
+++ b/span.go
@@ -51,6 +51,7 @@ type Span interface {
 	End()
 	IsEntry() bool
 	IsExit() bool
+	IsValid() bool
 }
 
 func newLocalSpan(t *Tracer) *defaultSpan {
@@ -133,6 +134,10 @@ func (ds *defaultSpan) IsEntry() bool {
 
 func (ds *defaultSpan) IsExit() bool {
 	return ds.SpanType == SpanTypeExit
+}
+
+func (ds *defaultSpan) IsValid() bool {
+	return ds.EndTime.IsZero()
 }
 
 // SpanOption allows for functional options to adjust behaviour

--- a/span_test.go
+++ b/span_test.go
@@ -291,3 +291,14 @@ func Test_defaultSpan_SpanType(t *testing.T) {
 		})
 	}
 }
+
+func Test_defaultSpan_Valid(t *testing.T) {
+	ds := &defaultSpan{}
+	if ds.IsValid() != true {
+		t.Error("default span is not valid")
+	}
+	ds.End()
+	if ds.IsValid() != false {
+		t.Error("default span is valid after call End")
+	}
+}


### PR DESCRIPTION
Now the `Span.End()` method will get panic when call it repeatedly, to improve the robustness, we can add a `IsValid` method to check if the current span is still valid in the context, and according to https://github.com/SkyAPM/go2sky-plugins/pull/40#issuecomment-1001549312, we can provide this method to avoid creating a span from a invalid parent span

For a valid span, the `EndTime` value shoud be zero, and after call `End()`, it will be assigned the value of `time.Now()`, so I check this value to determine if current span is valid:

```go
func (ds *defaultSpan) IsValid() bool {
	return ds.EndTime.IsZero()
}
```

This PR will add a new method to the `Span` interface, so we may need to consider if it caused a break change and it may not be thread-safe in some concurrency scenarios.