### PR TITLE
Add Log Interface

### DIFF
--- a/docs/GRPC-Reporter-Option.md
+++ b/docs/GRPC-Reporter-Option.md
@@ -2,12 +2,12 @@
 
 `GRPCReporterOption` allows for functional options to adjust behaviour of a `gRPC` reporter to be created by `NewGRPCReporter`.
 
-|    Function    | Describe |
-| ---------- | --- |
-| `reporter.WithLogger` |  setup logger for gRPC reporter |
-| `reporter.WithCheckInterval` |  setup service and endpoint registry check interval |
-| `reporter.WithMaxSendQueueSize` | setup send span queue buffer length |
-| `reporter.WithInstanceProps` |  setup service instance properties eg: org=SkyAPM |
-| `reporter.WithTransportCredentials` |  setup transport layer security |
-| `reporter.WithAuthentication` |  used Authentication for gRPC |
-| `reporter.WithCDS` |  setup CDS service |
+| Function                            | Describe                                           |
+|-------------------------------------|----------------------------------------------------|
+| `reporter.WithLog`                  | setup log for gRPC reporter                        |
+| `reporter.WithCheckInterval`        | setup service and endpoint registry check interval |
+| `reporter.WithMaxSendQueueSize`     | setup send span queue buffer length                |
+| `reporter.WithInstanceProps`        | setup service instance properties eg: org=SkyAPM   |
+| `reporter.WithTransportCredentials` | setup transport layer security                     |
+| `reporter.WithAuthentication`       | used Authentication for gRPC                       |
+| `reporter.WithCDS`                  | setup CDS service                                  |

--- a/logger/log.go
+++ b/logger/log.go
@@ -23,10 +23,10 @@ type Log interface {
 	Info(args ...interface{})
 	// Infof logs to the INFO log.
 	Infof(format string, args ...interface{})
-	// Warning logs to the WARNING and INFO logs.
-	Warning(args ...interface{})
-	// Warningf logs to the WARNING and INFO logs.
-	Warningf(format string, args ...interface{})
+	// Warn logs to the WARNING and INFO logs.
+	Warn(args ...interface{})
+	// Warnf logs to the WARNING and INFO logs.
+	Warnf(format string, args ...interface{})
 	// Error logs to the ERROR, WARNING, and INFO logs.
 	Error(args ...interface{})
 	// Errorf logs to the ERROR, WARNING, and INFO logs.
@@ -45,11 +45,11 @@ func (d defaultLogger) Infof(format string, args ...interface{}) {
 	d.logger.Printf(format, args...)
 }
 
-func (d defaultLogger) Warning(args ...interface{}) {
+func (d defaultLogger) Warn(args ...interface{}) {
 	d.logger.Print(args...)
 }
 
-func (d defaultLogger) Warningf(format string, args ...interface{}) {
+func (d defaultLogger) Warnf(format string, args ...interface{}) {
 	d.logger.Printf(format, args...)
 }
 

--- a/logger/log.go
+++ b/logger/log.go
@@ -1,0 +1,69 @@
+//
+// Copyright 2022 SkyAPM org
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package logger
+
+import "log"
+
+type Log interface {
+	// Info logs to the INFO log.
+	Info(args ...interface{})
+	// Infof logs to the INFO log.
+	Infof(format string, args ...interface{})
+	// Warning logs to the WARNING and INFO logs.
+	Warning(args ...interface{})
+	// Warningf logs to the WARNING and INFO logs.
+	Warningf(format string, args ...interface{})
+	// Error logs to the ERROR, WARNING, and INFO logs.
+	Error(args ...interface{})
+	// Errorf logs to the ERROR, WARNING, and INFO logs.
+	Errorf(format string, args ...interface{})
+}
+
+type defaultLogger struct {
+	logger *log.Logger
+}
+
+func (d defaultLogger) Info(args ...interface{}) {
+	d.logger.Print(args...)
+}
+
+func (d defaultLogger) Infof(format string, args ...interface{}) {
+	d.logger.Printf(format, args...)
+}
+
+func (d defaultLogger) Warning(args ...interface{}) {
+	d.logger.Print(args...)
+}
+
+func (d defaultLogger) Warningf(format string, args ...interface{}) {
+	d.logger.Printf(format, args...)
+}
+
+func (d defaultLogger) Error(args ...interface{}) {
+	d.logger.Print(args...)
+}
+
+func (d defaultLogger) Errorf(format string, args ...interface{}) {
+	d.logger.Printf(format, args...)
+}
+
+// NewDefaultLogger Creates a new Log
+func NewDefaultLogger(logger *log.Logger) Log {
+	return &defaultLogger{
+		logger: logger,
+	}
+}

--- a/reporter/grpc_test.go
+++ b/reporter/grpc_test.go
@@ -21,10 +21,13 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"reflect"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/SkyAPM/go2sky"
+	"github.com/SkyAPM/go2sky/logger"
 	"github.com/SkyAPM/go2sky/propagation"
 	mock "github.com/SkyAPM/go2sky/reporter/grpc/management/mock_management"
 	"github.com/golang/mock/gomock"
@@ -133,7 +136,10 @@ func TestGRPCReporterOption(t *testing.T) {
 	instanceProps["org"] = "SkyAPM"
 
 	// log
-	logger := log.New(os.Stderr, "WithLogger", log.LstdFlags)
+	log1 := log.New(os.Stderr, "WithLogger", log.LstdFlags)
+
+	// custom log
+	log2 := &testLog{}
 
 	// tls
 	creds, err := credentials.NewClientTLSFromFile("../test/test-data/certs/cert.crt", "SkyAPM.org")
@@ -180,10 +186,21 @@ func TestGRPCReporterOption(t *testing.T) {
 		},
 		{
 			name:   "with logger",
-			option: WithLogger(logger),
+			option: WithLogger(log1),
 			verifyFunc: func(t *testing.T, reporter *gRPCReporter) {
-				if reporter.logger != logger {
+				log3 := reflect.ValueOf(reporter.logger).Elem().FieldByName("logger")
+				log3 = reflect.NewAt(log3.Type(), unsafe.Pointer(log3.UnsafeAddr())).Elem()
+				if log3.Interface() != log1 {
 					t.Error("error are not set logger")
+				}
+			},
+		},
+		{
+			name:   "with log",
+			option: WithLog(log2),
+			verifyFunc: func(t *testing.T, reporter *gRPCReporter) {
+				if reporter.logger != log2 {
+					t.Error("error are not set log")
 				}
 			},
 		},
@@ -258,7 +275,7 @@ func TestGRPCReporter_reportInstanceProperties(t *testing.T) {
 
 func createGRPCReporter() *gRPCReporter {
 	reporter := &gRPCReporter{
-		logger: log.New(os.Stderr, "go2sky", log.LstdFlags),
+		logger: logger.NewDefaultLogger(log.New(os.Stderr, "go2sky", log.LstdFlags)),
 	}
 	return reporter
 }
@@ -287,4 +304,32 @@ func (e instancePropertiesMatcher) Matches(x interface{}) bool {
 
 func (e instancePropertiesMatcher) String() string {
 	return fmt.Sprintf("is equal to %v", e.x)
+}
+
+// testLog test only
+type testLog struct {
+}
+
+func (t testLog) Info(args ...interface{}) {
+	fmt.Print(args...)
+}
+
+func (t testLog) Infof(format string, args ...interface{}) {
+	fmt.Printf(format, args...)
+}
+
+func (t testLog) Warning(args ...interface{}) {
+	fmt.Print(args...)
+}
+
+func (t testLog) Warningf(format string, args ...interface{}) {
+	fmt.Printf(format, args...)
+}
+
+func (t testLog) Error(args ...interface{}) {
+	fmt.Print(args...)
+}
+
+func (t testLog) Errorf(format string, args ...interface{}) {
+	fmt.Printf(format, args...)
 }

--- a/reporter/grpc_test.go
+++ b/reporter/grpc_test.go
@@ -318,11 +318,11 @@ func (t testLog) Infof(format string, args ...interface{}) {
 	fmt.Printf(format, args...)
 }
 
-func (t testLog) Warning(args ...interface{}) {
+func (t testLog) Warn(args ...interface{}) {
 	fmt.Print(args...)
 }
 
-func (t testLog) Warningf(format string, args ...interface{}) {
+func (t testLog) Warnf(format string, args ...interface{}) {
 	fmt.Printf(format, args...)
 }
 


### PR DESCRIPTION
### Background

Now [GRPCReporter](https://github.com/SkyAPM/go2sky/blob/master/reporter/grpc.go#L140) can only use [log.Logger](https://github.com/golang/go/blob/master/src/log/log.go#L53) to output logs, but there are many good log libraries, such as [zap](https://github.com/uber-go/zap), [logrus](https://github.com/sirupsen/logrus), I think we should design a logging interface and let the user decide which one to use.

### Design

```go
type Log interface {
	// Info logs to the INFO log.
	Info(args ...interface{})
	// Infof logs to the INFO log.
	Infof(format string, args ...interface{})
	// Warning logs to the WARNING and INFO logs.
	Warn(args ...interface{})
	// Warningf logs to the WARNING and INFO logs.
	Warnf(format string, args ...interface{})
	// Error logs to the ERROR, WARNING, and INFO logs.
	Error(args ...interface{})
	// Errorf logs to the ERROR, WARNING, and INFO logs.
	Errorf(format string, args ...interface{})
}
```

### Use Case

+ golang/log (default)

```go
	logger := log.New(os.Stderr, "go2sky", log.LstdFlags)

	reporter, _ := NewGRPCReporter("127.0.0.1:11800", WithLogger(logger))
```

+ zap

```go
	logger, _ := zap.NewProduction()
	defer logger.Sync() // flushes buffer, if any
	sugar := logger.Sugar()

	reporter, _ := NewGRPCReporter("127.0.0.1:11800", WithLog(sugar))
```

+ logrus

```go
	logger := logrus.New()
	
	reporter, _ := NewGRPCReporter("127.0.0.1:11800", WithLog(logger))
```