### PR TITLE
Add process metadata file for work with eBPF agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ The rover side scans all processes, find out which process contains this metadat
 
 ### Metadata File
 
-The metadata file use to save metadata with current process, it save in: `{TMPDIR}/apache_skyuwalking/process/{pid}/metadata.properties`.
+The metadata file use to save metadata with current process, it save in: `{TMPDIR}/apache_skywalking/process/{pid}/metadata.properties`.
 
 Also, when the go2sky keep alive with backend, modify and open time of the metadata file would be updated.
 

--- a/README.md
+++ b/README.md
@@ -264,5 +264,36 @@ Golang agent supports the following dynamic configurations.
 |:-----------------:|:----------------------------------------------------------------------------------------:|:--------------------:|
 | agent.sample_rate | The percentage of trace when sampling. It's `[0, 1]`, Same with `WithSampler` parameter. |         0.1          |
 
+## Process
+
+This feature is used in cooperation with the [skywalking-rover](https://github.com/apache/skywalking-rover) project.
+
+When go2sky keeps alive with the backend, it would write a metadata file to the local (temporary directory) at the same time, which describes the information of the current process.
+The rover side scans all processes, find out which process contains this metadata file, and update the confirmed file. Finally, the rover could collect, profiling, with this process.
+
+### Metadata File
+
+The metadata file use to save metadata with current process, it save in: `{TMPDIR}/apache_skyuwalking/process/{pid}/metadata.properties`.
+
+Also, when the go2sky keep alive with backend, modify and open time of the metadata file would be updated.
+
+| Key | Type | Description |
+|-----|------|------------|
+|layer|string|this process layer.|
+|service_name|string|this process service name.|
+|instance_name|string|this process instance name.|
+|process_name|string|this process process name, it's same with the instance name.|
+|properties|json|the properties in instance, the process labels also in the properties value.|
+|label_key_in_properties|string|the key name of the process labels.|
+|language|string|current process language, which is `golang`.|
+
+### Confirmation file
+
+The confirmation file used to let the go2sky known, the rover side have detected current process, so don't need to keep update the metadata file again. It save in: `{TMPDIR}/apache_skyuwalking/process/{pid}/metadata-confirm.properties`.
+
+| Key | Type | Description |
+|-----|------|-------------|
+|status|string|the status of check process|
+
 # License
 Apache License 2.0. See [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ Below is the full list of supported environment variables you can set to customi
 |         `SW_AGENT_COLLECTOR_HEARTBEAT_PERIOD`          |                                                                                                                               Agent heartbeat report period. Unit, second                                                                                                                               |         20         |
 | `SW_AGENT_COLLECTOR_GET_AGENT_DYNAMIC_CONFIG_INTERVAL` |                                                                                                                         Sniffer get agent dynamic config interval. Unit, second                                                                                                                         |         20         |
 |        `SW_AGENT_COLLECTOR_MAX_SEND_QUEUE_SIZE`        |                                                                                                                                      Send span queue buffer length                                                                                                                                      |       30000        |
+|         `SW_AGENT_PROCESS_STATUS_HOOK_ENABLE`          |                                                                                                                                 Enable the Process Status Hook feature                                                                                                                                  |       false        |
+|               `SW_AGENT_PROCESS_LABELS`                |                                                                                                                       The labels of the process, multiple labels split by ","                                                                                                                           |       unset        |
 
 
 ## CDS - Configuration Discovery Service
@@ -264,12 +266,12 @@ Golang agent supports the following dynamic configurations.
 |:-----------------:|:----------------------------------------------------------------------------------------:|:--------------------:|
 | agent.sample_rate | The percentage of trace when sampling. It's `[0, 1]`, Same with `WithSampler` parameter. |         0.1          |
 
-## Process
+## Process Status Hook
 
 This feature is used in cooperation with the [skywalking-rover](https://github.com/apache/skywalking-rover) project.
 
 When go2sky keeps alive with the backend, it would write a metadata file to the local (temporary directory) at the same time, which describes the information of the current process.
-The rover side scans all processes, find out which process contains this metadata file, and update the confirmed file. Finally, the rover could collect, profiling, with this process.
+The rover side scans all processes, find out which process contains this metadata file. Finally, the rover could collect, profiling, with this process.
 
 ### Metadata File
 
@@ -284,16 +286,8 @@ Also, when the go2sky keep alive with backend, modify and open time of the metad
 |instance_name|string|this process instance name.|
 |process_name|string|this process process name, it's same with the instance name.|
 |properties|json|the properties in instance, the process labels also in the properties value.|
-|label_key_in_properties|string|the key name of the process labels.|
+|labels|string|the process labels, multiple labels split by ",".|
 |language|string|current process language, which is `golang`.|
-
-### Confirmation file
-
-The confirmation file used to let the go2sky known, the rover side have detected current process, so don't need to keep update the metadata file again. It save in: `{TMPDIR}/apache_skyuwalking/process/{pid}/metadata-confirm.properties`.
-
-| Key | Type | Description |
-|-----|------|-------------|
-|status|string|the status of check process|
 
 # License
 Apache License 2.0. See [LICENSE](LICENSE) file for details.

--- a/docs/GRPC-Reporter-Option.md
+++ b/docs/GRPC-Reporter-Option.md
@@ -13,4 +13,5 @@
 | `reporter.WithCDS`                  | setup CDS service                                  |
 | `reporter.WithLayer`                | setup layer                                        |
 | `reporter.WithFAASLayer`            | setup layer to FAAS                                |
-| `reporter.WithLabels`               | setup labels bind to process                       |
+| `reporter.WithProcessLabels`        | setup labels bind to process                       |
+| `reporter.WithProcessStatusHook`    | setup is enabled the process status                |

--- a/docs/GRPC-Reporter-Option.md
+++ b/docs/GRPC-Reporter-Option.md
@@ -13,3 +13,4 @@
 | `reporter.WithCDS`                  | setup CDS service                                  |
 | `reporter.WithLayer`                | setup layer                                        |
 | `reporter.WithFAASLayer`            | setup layer to FAAS                                |
+| `reporter.WithLabels`               | setup labels bind to process                       |

--- a/reporter/grpc.go
+++ b/reporter/grpc.go
@@ -116,6 +116,10 @@ type gRPCReporter struct {
 
 	// Instance belong layer name which define in the backend
 	layer string
+
+	// The process metadata and is enabled the process status hook
+	processLabels           []string
+	processStatusHookEnable bool
 }
 
 func (r *gRPCReporter) Boot(service string, serviceInstance string, cdsWatchers []go2sky.AgentConfigChangeWatcher) {
@@ -315,8 +319,10 @@ func (r *gRPCReporter) check() {
 				break
 			}
 
-			// report the process
-			reportProcess(r)
+			// report the process status
+			if r.processStatusHookEnable {
+				reportProcess(r)
+			}
 
 			if !instancePropertiesSubmitted {
 				err := r.reportInstanceProperties()

--- a/reporter/grpc.go
+++ b/reporter/grpc.go
@@ -316,7 +316,7 @@ func (r *gRPCReporter) check() {
 			}
 
 			// report the process
-			reportProcessIFNeed(r)
+			reportProcess(r)
 
 			if !instancePropertiesSubmitted {
 				err := r.reportInstanceProperties()

--- a/reporter/grpc.go
+++ b/reporter/grpc.go
@@ -202,6 +202,7 @@ func (r *gRPCReporter) Close() {
 		close(r.sendCh)
 	} else {
 		r.closeGRPCConn()
+		cleanupProcessDirectory(r)
 	}
 }
 
@@ -313,6 +314,9 @@ func (r *gRPCReporter) check() {
 			if r.conn.GetState() == connectivity.Shutdown {
 				break
 			}
+
+			// report the process
+			reportProcessIFNeed(r)
 
 			if !instancePropertiesSubmitted {
 				err := r.reportInstanceProperties()

--- a/reporter/grpc_env.go
+++ b/reporter/grpc_env.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -32,6 +33,8 @@ const (
 	swAgentCollectorGetAgentDynamicConfigInterval = "SW_AGENT_COLLECTOR_GET_AGENT_DYNAMIC_CONFIG_INTERVAL"
 	swAgentCollectorBackendServices               = "SW_AGENT_COLLECTOR_BACKEND_SERVICES"
 	swAgentCollectorMaxSendQueueSize              = "SW_AGENT_COLLECTOR_MAX_SEND_QUEUE_SIZE"
+	swAgentProcessStatusHookEnable                = "SW_AGENT_PROCESS_STATUS_HOOK_ENABLE"
+	swAgentProcessLabels                          = "SW_AGENT_PROCESS_LABELS"
 )
 
 // serverAddrFormEnv read the backend service address in the environment variable
@@ -74,6 +77,19 @@ func gRPCReporterOptionsFormEnv() (opts []GRPCReporterOption, err error) {
 			return nil, err
 		}
 		opts = append(opts, WithMaxSendQueueSize(int(size)))
+	}
+
+	if value := os.Getenv(swAgentProcessStatusHookEnable); value != "" {
+		enable, err1 := strconv.ParseBool(value)
+		if err1 != nil {
+			return nil, err
+		}
+		opts = append(opts, WithProcessStatusHook(enable))
+	}
+
+	if value := os.Getenv(swAgentProcessLabels); value != "" {
+		labels := strings.Split(value, ",")
+		opts = append(opts, WithProcessLabels(labels))
 	}
 	return
 }

--- a/reporter/grpc_opts.go
+++ b/reporter/grpc_opts.go
@@ -18,6 +18,7 @@ package reporter
 
 import (
 	"log"
+	"strings"
 	"time"
 
 	"github.com/SkyAPM/go2sky/logger"
@@ -98,5 +99,15 @@ func WithLayer(layer string) GRPCReporterOption {
 func WithFAASLayer() GRPCReporterOption {
 	return func(r *gRPCReporter) {
 		r.layer = "FAAS"
+	}
+}
+
+// WithLabels setup labels bind to process
+func WithLabels(labels []string) GRPCReporterOption {
+	return func(t *gRPCReporter) {
+		if t.instanceProps == nil {
+			t.instanceProps = make(map[string]string)
+		}
+		t.instanceProps[ProcessLabelKey] = strings.Join(labels, ",")
 	}
 }

--- a/reporter/grpc_opts.go
+++ b/reporter/grpc_opts.go
@@ -102,12 +102,20 @@ func WithFAASLayer() GRPCReporterOption {
 	}
 }
 
-// WithLabels setup labels bind to process
-func WithLabels(labels []string) GRPCReporterOption {
+// WithProcessLabels setup labels bind to process
+func WithProcessLabels(labels []string) GRPCReporterOption {
 	return func(t *gRPCReporter) {
+		t.processLabels = labels
 		if t.instanceProps == nil {
 			t.instanceProps = make(map[string]string)
 		}
 		t.instanceProps[ProcessLabelKey] = strings.Join(labels, ",")
+	}
+}
+
+// WithProcessStatusHook setup is enabled the process status
+func WithProcessStatusHook(enable bool) GRPCReporterOption {
+	return func(r *gRPCReporter) {
+		r.processStatusHookEnable = enable
 	}
 }

--- a/reporter/process.go
+++ b/reporter/process.go
@@ -67,7 +67,7 @@ func initProcessStat(r *gRPCReporter) *processStat {
 
 // Report the current process metadata to local file
 // using to work with eBPF agent
-func reportProcessIFNeed(r *gRPCReporter) {
+func reportProcess(r *gRPCReporter) {
 	if process == nil {
 		process = initProcessStat(r)
 	}

--- a/reporter/process.go
+++ b/reporter/process.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
 	"strconv"
@@ -96,7 +97,7 @@ func reportProcessIFNeed(r *gRPCReporter) {
 }
 
 func (p *processStat) checkMetaConfirmed() (bool, error) {
-	confirmData, err := os.ReadFile(process.confirmFilePath)
+	confirmData, err := ioutil.ReadFile(process.confirmFilePath)
 	if err != nil {
 		return false, fmt.Errorf("could not read process confirm file: %s, %v", process.confirmFilePath, err)
 	}

--- a/reporter/process.go
+++ b/reporter/process.go
@@ -1,0 +1,196 @@
+//
+// Copyright 2022 SkyAPM org
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package reporter
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	commonv3 "skywalking.apache.org/repo/goapi/collect/common/v3"
+)
+
+type ProcessReportStatus int8
+
+const (
+	ProcessLabelKey = "processLabels"
+
+	NotInit ProcessReportStatus = iota
+	Reported
+	Confirmed
+	Closed
+)
+
+var process *processStat
+
+type processStat struct {
+	basePath        string
+	metaFilePath    string
+	confirmFilePath string
+	status          ProcessReportStatus
+	shutdownOnce    sync.Once
+}
+
+func initProcessStat(r *gRPCReporter) *processStat {
+	basePath := path.Join(os.TempDir(), "apache_skywalking", "process", strconv.Itoa(os.Getpid()))
+	metaFilePath := path.Join(basePath, "metadata.properties")
+	confirmFilePath := path.Join(basePath, "metadata-confirm.properties")
+
+	return &processStat{
+		basePath:        basePath,
+		metaFilePath:    metaFilePath,
+		confirmFilePath: confirmFilePath,
+		status:          NotInit,
+	}
+}
+
+// Report the current process metadata to local file
+// using to work with eBPF agent
+func reportProcessIFNeed(r *gRPCReporter) {
+	if process == nil {
+		process = initProcessStat(r)
+	}
+
+	if process.status == NotInit {
+		// create meta and confirm file
+		if p, err := process.initMetaAndConfirmFile(r); err != nil {
+			r.logger.Warnf("process file init failure: %s, %v", p, err)
+		}
+		process.status = Reported
+	} else if process.status == Reported {
+		// already init the reporter, check confirmed or update modify time on metadata file
+		if confirmed, err := process.checkMetaConfirmed(); err != nil {
+			r.logger.Warnf("check process confirm failure, %v", err)
+		} else if confirmed {
+			r.logger.Infof("the process information have been confirmed")
+			process.status = Confirmed
+			return
+		}
+
+		// keep the metadata file alive(update modify time)
+		updateTime := time.Now()
+		if err := os.Chtimes(process.metaFilePath, updateTime, updateTime); err != nil {
+			r.logger.Warnf("keep the process metadata alive failure: %v", err)
+		}
+	}
+}
+
+func (p *processStat) checkMetaConfirmed() (bool, error) {
+	confirmData, err := os.ReadFile(process.confirmFilePath)
+	if err != nil {
+		return false, fmt.Errorf("could not read process confirm file: %s, %v", process.confirmFilePath, err)
+	}
+	data := strings.TrimSpace(string(confirmData))
+	return data == "status=success", nil
+}
+
+func (p *processStat) initMetaAndConfirmFile(r *gRPCReporter) (string, error) {
+	// create base directory
+	basePath := process.basePath
+	if err := os.RemoveAll(basePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return basePath, err
+	}
+	if err := os.MkdirAll(basePath, 0o700); err != nil {
+		return basePath, err
+	}
+
+	// create and write metadata file
+	metadataFile := process.metaFilePath
+	if metaFile, err := os.Create(metadataFile); err != nil {
+		return metadataFile, err
+	} else {
+		if content, err := p.buildMetadataContent(r); err != nil {
+			return metadataFile, err
+		} else if _, err = metaFile.WriteString(content); err != nil {
+			return metadataFile, err
+		}
+	}
+
+	// create confirm file
+	if _, err := os.Create(process.confirmFilePath); err != nil {
+		return process.confirmFilePath, err
+	}
+	return "", nil
+}
+
+func (p *processStat) buildMetadataContent(g *gRPCReporter) (string, error) {
+	layer := g.layer
+	if layer == "" {
+		layer = "GENERAL"
+	}
+
+	propertiesJson, err := p.buildPropertiesJson(g)
+	if err != nil {
+		return "", err
+	}
+
+	metadata := map[string]string{
+		"layer":                   layer,
+		"service_name":            g.service,
+		"instance_name":           g.serviceInstance,
+		"process_name":            g.serviceInstance, // process name is same with instance name
+		"properties":              propertiesJson,
+		"label_key_in_properties": ProcessLabelKey,
+		"language":                "golang",
+	}
+
+	result := ""
+	for k, v := range metadata {
+		result += fmt.Sprintf("%s=%s\n", k, v)
+	}
+	return result, nil
+}
+
+func (p *processStat) buildPropertiesJson(g *gRPCReporter) (string, error) {
+	props := buildOSInfo()
+	if g.instanceProps != nil {
+		for k, v := range g.instanceProps {
+			props = append(props, &commonv3.KeyStringValuePair{
+				Key:   k,
+				Value: v,
+			})
+		}
+	}
+
+	properties := make(map[string]string)
+	for _, p := range props {
+		properties[p.Key] = p.Value
+	}
+	bytes, err := json.Marshal(properties)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
+func cleanupProcessDirectory(r *gRPCReporter) {
+	if process == nil {
+		return
+	}
+	process.shutdownOnce.Do(func() {
+		if err := os.RemoveAll(process.basePath); err != nil && r != nil {
+			r.logger.Warnf("could delete process: %s, %v", process.basePath, err)
+		}
+		process.status = Closed
+	})
+}

--- a/test/e2e/example-server/main.go
+++ b/test/e2e/example-server/main.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/SkyAPM/go2sky"
@@ -30,12 +29,11 @@ import (
 )
 
 var (
-	grpc          bool
-	oapServer     string
-	upstreamURL   string
-	listenAddr    string
-	serviceName   string
-	processLabels string
+	grpc        bool
+	oapServer   string
+	upstreamURL string
+	listenAddr  string
+	serviceName string
 
 	client *http.Client
 )
@@ -46,7 +44,6 @@ func init() {
 	flag.StringVar(&upstreamURL, "upstream-url", "upstream-service", "upstream service url")
 	flag.StringVar(&listenAddr, "listen-addr", ":8080", "listen address")
 	flag.StringVar(&serviceName, "service-name", "go2sky", "service name")
-	flag.StringVar(&processLabels, "process-labels", "", "process labels")
 }
 
 func ServerHTTP(writer http.ResponseWriter, request *http.Request) {
@@ -80,15 +77,10 @@ func ServerHTTP(writer http.ResponseWriter, request *http.Request) {
 func main() {
 	flag.Parse()
 
-	labels := make([]string, 0)
-	if processLabels != "" {
-		labels = strings.Split(processLabels, ",")
-	}
-
 	var report go2sky.Reporter
 	var err error
 	if grpc {
-		report, err = reporter.NewGRPCReporter(oapServer, reporter.WithCDS(10), reporter.WithLabels(labels))
+		report, err = reporter.NewGRPCReporter(oapServer, reporter.WithCDS(10))
 		if err != nil {
 			log.Fatalf("crate grpc reporter error: %v \n", err)
 		}

--- a/test/e2e/example-server/main.go
+++ b/test/e2e/example-server/main.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/SkyAPM/go2sky"
@@ -29,11 +30,12 @@ import (
 )
 
 var (
-	grpc        bool
-	oapServer   string
-	upstreamURL string
-	listenAddr  string
-	serviceName string
+	grpc          bool
+	oapServer     string
+	upstreamURL   string
+	listenAddr    string
+	serviceName   string
+	processLabels string
 
 	client *http.Client
 )
@@ -44,6 +46,7 @@ func init() {
 	flag.StringVar(&upstreamURL, "upstream-url", "upstream-service", "upstream service url")
 	flag.StringVar(&listenAddr, "listen-addr", ":8080", "listen address")
 	flag.StringVar(&serviceName, "service-name", "go2sky", "service name")
+	flag.StringVar(&processLabels, "process-labels", "", "process labels")
 }
 
 func ServerHTTP(writer http.ResponseWriter, request *http.Request) {
@@ -77,10 +80,15 @@ func ServerHTTP(writer http.ResponseWriter, request *http.Request) {
 func main() {
 	flag.Parse()
 
+	labels := make([]string, 0)
+	if processLabels != "" {
+		labels = strings.Split(processLabels, ",")
+	}
+
 	var report go2sky.Reporter
 	var err error
 	if grpc {
-		report, err = reporter.NewGRPCReporter(oapServer, reporter.WithCDS(10))
+		report, err = reporter.NewGRPCReporter(oapServer, reporter.WithCDS(10), reporter.WithLabels(labels))
 		if err != nil {
 			log.Fatalf("crate grpc reporter error: %v \n", err)
 		}


### PR DESCRIPTION
Now we have [skywalking-rover](https://github.com/apache/skywalking-rover), which could detect processes from the local machine. Also, go2sky is one of the official agents in the skywalking ecosystem. We could let these two projects cooperate. If the local machine already has service use go2sky, then the rover could find this process automatically. Finally, the rover side could collect, profiling, etc. 

In principle, when go2sky performs keep alive with the backend, it would write a metadata file to the local (temporary directory) at the same time, which describes the information of the current process. The Rover side scans all processes, find out which processes contain this metadata file, and update the confirmed files. Finally, if go2sky sees that it has been confirmed, it would not modify the files again. 