### PR TITLE
fix: When serves both http&websocket,ws connection denied with "bad handshake".

### DIFF
--- a/plugins/http/server.go
+++ b/plugins/http/server.go
@@ -17,7 +17,10 @@
 package http
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 	"time"
@@ -126,6 +129,14 @@ func (rww *responseWriterWrapper) Write(bytes []byte) (int, error) {
 func (rww *responseWriterWrapper) WriteHeader(statusCode int) {
 	rww.statusCode = statusCode
 	rww.w.WriteHeader(statusCode)
+}
+
+func (rww *responseWriterWrapper) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	h, ok := rww.w.(http.Hijacker)
+	if !ok {
+		return nil, nil, errors.New("NotImplementHijacker")
+	}
+	return h.Hijack()
 }
 
 func getOperationName(name string, r *http.Request) string {


### PR DESCRIPTION
When using package gorilla/websocket, calls Upgrader.Upgrade(w http.ResponseWriter, r *http.Request, responseHeader http.Header),it asserts the ResponseWriter to be a Hijacker implementation, if assertion fails ws connection will be denied.

Client error:  `websocket: bad handshake`
Server error:  `websocket: response does not implement http.Hijacker`

gorilla/websocket code details：server.go
```go
173   	h, ok := w.(http.Hijacker)
174   	if !ok {
175  		return u.returnError(w, r, http.StatusInternalServerError, "websocket: response does not implement http.Hijacker")
176  	}
```